### PR TITLE
Make render system use `Local` for Vello Renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+## 0.1.2 (2024-04-08)
+
+- Fixes a window hang issue in bevy on native platforms
+
 ## 0.1.1 (2024-04-04)
 
 ### fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/loopystudios/bevy_vello"
 

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -1,5 +1,5 @@
 use super::extract::{self, ExtractedPixelScale, SSRenderTarget};
-use super::{prepare, systems, BevyVelloRenderer, LottieRenderer};
+use super::{prepare, systems, LottieRenderer};
 use crate::render::extract::ExtractedRenderText;
 use crate::render::SSRT_SHADER_HANDLE;
 use crate::{VelloCanvasMaterial, VelloFont};
@@ -10,7 +10,6 @@ use bevy::render::render_asset::RenderAssetPlugin;
 use bevy::render::renderer::RenderDevice;
 use bevy::render::{Render, RenderApp, RenderSet};
 use bevy::sprite::Material2dPlugin;
-use vello::{AaSupport, Renderer, RendererOptions};
 
 pub struct VelloRenderPlugin;
 
@@ -65,34 +64,5 @@ impl Plugin for VelloRenderPlugin {
             Update,
             (systems::resize_rendertargets, systems::clear_when_empty),
         );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
-
-        let device = render_app
-            .world
-            .get_resource::<RenderDevice>()
-            .expect("bevy_vello: unable to get render device");
-
-        render_app.insert_non_send_resource(BevyVelloRenderer(
-            Renderer::new(
-                device.wgpu_device(),
-                RendererOptions {
-                    surface_format: None,
-                    use_cpu: false,
-                    antialiasing_support: AaSupport {
-                        area: true,
-                        msaa8: false,
-                        msaa16: false,
-                    },
-                    num_init_threads: None,
-                },
-            )
-            .unwrap(),
-        ));
     }
 }

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -47,7 +47,12 @@ impl Plugin for VelloRenderPlugin {
                 )
                     .in_set(RenderSet::Prepare),
             )
-            .add_systems(Render, systems::render_scene.in_set(RenderSet::Render));
+            .add_systems(
+                Render,
+                systems::render_scene
+                    .in_set(RenderSet::Render)
+                    .run_if(resource_exists::<RenderDevice>),
+            );
 
         app.add_plugins((
             Material2dPlugin::<VelloCanvasMaterial>::default(),

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -9,7 +9,6 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 use bevy::render::view::NoFrustumCulling;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
-use bevy::transform::commands;
 use bevy::window::{WindowResized, WindowResolution};
 use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 
@@ -61,8 +60,8 @@ pub fn render_scene(
     mut vello_renderer: Local<Option<BevyVelloRenderer>>,
     mut velottie_renderer: ResMut<LottieRenderer>,
 ) {
-    let Some(renderer) = vello_renderer.as_mut() else {
-        vello_renderer.replace(BevyVelloRenderer(
+    let renderer = vello_renderer.get_or_insert_with(|| {
+        BevyVelloRenderer(
             Renderer::new(
                 device.wgpu_device(),
                 RendererOptions {
@@ -77,9 +76,8 @@ pub fn render_scene(
                 },
             )
             .unwrap(),
-        ));
-        return;
-    };
+        )
+    });
 
     if let Ok(SSRenderTarget(render_target_image)) = ss_render_target.get_single() {
         let gpu_image = gpu_images.get(render_target_image).unwrap();

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -9,8 +9,9 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 use bevy::render::view::NoFrustumCulling;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
+use bevy::transform::commands;
 use bevy::window::{WindowResized, WindowResolution};
-use vello::{RenderParams, Scene};
+use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 
 use super::extract::{ExtractedRenderAsset, ExtractedRenderText, SSRenderTarget};
 use super::prepare::PreparedAffine;
@@ -57,12 +58,26 @@ pub fn render_scene(
     gpu_images: Res<RenderAssets<Image>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
-    vello_renderer: Option<NonSendMut<BevyVelloRenderer>>,
+    mut vello_renderer: Local<Option<BevyVelloRenderer>>,
     mut velottie_renderer: ResMut<LottieRenderer>,
 ) {
-    let mut renderer = if let Some(renderer) = vello_renderer {
-        renderer
-    } else {
+    let Some(renderer) = vello_renderer.as_mut() else {
+        vello_renderer.replace(BevyVelloRenderer(
+            Renderer::new(
+                device.wgpu_device(),
+                RendererOptions {
+                    surface_format: None,
+                    use_cpu: false,
+                    antialiasing_support: AaSupport {
+                        area: true,
+                        msaa8: false,
+                        msaa16: false,
+                    },
+                    num_init_threads: None,
+                },
+            )
+            .unwrap(),
+        ));
         return;
     };
 


### PR DESCRIPTION
The motivation for this began as a way to work around [this bevy issue](https://github.com/bevyengine/bevy/issues/12912), which it does successfully circumvent. But also this makes `render_scene` make proper use of `Local`, so this is also an general improvement.